### PR TITLE
OSDP_FMT Support

### DIFF
--- a/src/osdp_common.h
+++ b/src/osdp_common.h
@@ -288,7 +288,9 @@ union osdp_ephemeral_data {
 #define PD_FLAG_HAS_SCBK       BIT(12) /* PD has a dedicated SCBK */
 #define PD_FLAG_SC_DISABLED    BIT(13) /* master_key=NULL && scbk=NULL */
 #define PD_FLAG_PKT_BROADCAST  BIT(14) /* this packet was addressed to 0x7F */
-
+#if (CONFIG_EDGE_QR == 1)
+#define PD_FLAG_PDID_SET	  BIT(15) /* PD ID has been set by the readers */
+#endif
 #define PD_FLAG_ONLINE		   BIT(30)
 #define PD_FLAG_OFFLINE		   BIT(31)
 

--- a/src/osdp_cp.c
+++ b/src/osdp_cp.c
@@ -442,6 +442,10 @@ static int cp_decode_response(struct osdp_pd *pd, uint8_t *buf, int len)
 		pd->id.firmware_version = buf[pos++] << 16;
 		pd->id.firmware_version |= buf[pos++] << 8;
 		pd->id.firmware_version |= buf[pos++];
+#if (CONFIG_EDGE_QR == 1)
+		if (ISSET_FLAG(pd, PD_FLAG_PDID_SET) == 0)
+			SET_FLAG(pd, PD_FLAG_PDID_SET);
+#endif
 		ret = OSDP_CP_ERR_NONE;
 		break;
 	case REPLY_PDCAP:
@@ -1295,6 +1299,9 @@ static void cp_state_change(struct osdp_pd *pd, enum osdp_cp_state_e next)
 			if (ISSET_FLAG(pd, PD_FLAG_OFFLINE) == 0) {
 				SET_FLAG(pd, PD_FLAG_OFFLINE);
 				CLEAR_FLAG(pd, PD_FLAG_ONLINE);
+#if (CONFIG_EDGE_QR == 1)
+				CLEAR_FLAG(pd, PD_FLAG_PDID_SET);
+#endif
 				notify_pd_status(pd, false);
 			}
 		}

--- a/src/osdp_pd.c
+++ b/src/osdp_pd.c
@@ -879,15 +879,15 @@ static int pd_build_reply(struct osdp_pd *pd, uint8_t *buf, int max_len)
 		ret = OSDP_PD_ERR_NONE;
 		break;
 	case REPLY_MFGREP:
-		cmd = (struct osdp_cmd *)pd->ephemeral_data;
-		assert_buf_len(REPLY_MFGREP_LEN + cmd->mfg.length, max_len);
+		event = (struct osdp_event *)pd->ephemeral_data;
+		assert_buf_len(REPLY_MFGREP_LEN + event->mfgrep.length, max_len);
 		buf[len++] = pd->reply_id;
-		buf[len++] = BYTE_0(cmd->mfg.vendor_code);
-		buf[len++] = BYTE_1(cmd->mfg.vendor_code);
-		buf[len++] = BYTE_2(cmd->mfg.vendor_code);
-		buf[len++] = cmd->mfg.command;
-		memcpy(buf + len, cmd->mfg.data, cmd->mfg.length);
-		len += cmd->mfg.length;
+		buf[len++] = BYTE_0(event->mfgrep.vendor_code);
+		buf[len++] = BYTE_1(event->mfgrep.vendor_code);
+		buf[len++] = BYTE_2(event->mfgrep.vendor_code);
+		buf[len++] = event->mfgrep.command;
+		memcpy(buf + len, event->mfgrep.data, event->mfgrep.length);
+		len += event->mfgrep.length;
 		ret = OSDP_PD_ERR_NONE;
 		break;
 	case REPLY_FTSTAT:

--- a/src/osdp_pd.c
+++ b/src/osdp_pd.c
@@ -411,6 +411,7 @@ static int pd_decode_command(struct osdp_pd *pd, uint8_t *buf, int len)
 		pos++; /* Skip reply type info. */
 		pd->reply_id = REPLY_PDID;
 #endif
+		ret = OSDP_PD_ERR_NONE;
 		break;
 	case CMD_CAP:
 		if (len != CMD_CAP_DATA_LEN) {


### PR DESCRIPTION
1. Implemented OSDP_FMT
2. Manual cherry pick from commit # dd7b12f to clear the ring buffer when invalid header packet and rescan the buffer to find the valid header packet